### PR TITLE
Ensure that the disclaimer dialog has a unique element id

### DIFF
--- a/priv/templates/event/_ticket-warning.tpl
+++ b/priv/templates/event/_ticket-warning.tpl
@@ -17,24 +17,22 @@
               <span class="sr-only">Close</span>
             </button>
 
-            {% with m.rsc.page_ticket_disclaimer as page %}
-                <h2>{{ page.title }}</h2>
-                
-                {{ page.body }}
+            <h2>{{ m.rsc.page_ticket_disclaimer.title }}</h2>
 
-                {% wire id="ticket_disclaimer" type="submit" postback={set_skip_ticket_warning ticket_url=id.ticket_link} delegate="queercal_ticket_warning" %}
+            {{ m.rsc.page_ticket_disclaimer.body }}
 
-                <form id="ticket_disclaimer" method="post" action="postback">
-                    <label class="c-custom-checkbox">
-                        <input type="checkbox" id="is_hide_disclaimer" name="is_hide_disclaimer">
-                        {_ Hide this disclaimer for a while _}
-                    </label>
+            {% wire id=#disclaimer type="submit" postback={set_skip_ticket_warning ticket_url=id.ticket_link} delegate="queercal_ticket_warning" %}
 
-                    <button class="c-btn c-btn-tickets -icon-external">
-                        {_ Proceed to external ticket sale _}
-                    </button>
-                </form>
-            {% endwith %}
+            <form id="{{ #disclaimer }}" method="post" action="postback">
+                <label class="c-custom-checkbox">
+                    <input type="checkbox" id="is_hide_disclaimer" name="is_hide_disclaimer">
+                    {_ Hide this disclaimer for a while _}
+                </label>
+
+                <button class="c-btn c-btn-tickets -icon-external">
+                    {_ Proceed to external ticket sale _}
+                </button>
+            </form>
         </div>
     </dialog>
 {% endif %}


### PR DESCRIPTION
## 🏳️‍🌈 Queer Cal Pull Request

This pull request simplifies the `priv/templates/event/_ticket-warning.tpl` template by removing unnecessary usage of the `{% with %}` block and streamlining how the ticket disclaimer data is accessed. It also updates the form and element IDs to use a more consistent approach.

Template simplification and consistency improvements:

* Removed the `{% with %}` block and directly accessed `m.rsc.page_ticket_disclaimer` properties, reducing template nesting and improving readability. [[1]](diffhunk://#diff-5ed72eabed168b8f88a7bc4e4f74f657ef4f055f3bef5f3add799b390f2aa6cbL20-R26) [[2]](diffhunk://#diff-5ed72eabed168b8f88a7bc4e4f74f657ef4f055f3bef5f3add799b390f2aa6cbL37)
* Updated the `wire` and `form` element IDs to use a unique `#disclaimer` reference, ensuring uniqueness for each dialog